### PR TITLE
De-nesting f-strings for compatibility with Python 3.10

### DIFF
--- a/case/make_case.py
+++ b/case/make_case.py
@@ -92,12 +92,16 @@ if 'right' in args.side:
 
 if args.export_stl:
     if 'left' in args.side:
-        print(f"Export success case/stl/apiaster-left-tray{args.name_suffix}.stl: {export_stl(left_tray, f"case/stl/apiaster-left-tray{args.name_suffix}.stl")}")
-        print(f"Export success case/stl/apiaster-left-frame{args.name_suffix}.stl: {export_stl(left_frame, f"case/stl/apiaster-left-frame{args.name_suffix}.stl")}")
+        left_tray_stl = export_stl(left_tray, f"case/stl/apiaster-left-tray{args.name_suffix}.stl")
+        left_frame_stl = export_stl(left_frame, f"case/stl/apiaster-left-frame{args.name_suffix}.stl")
+        print(f"Export success case/stl/apiaster-left-tray{args.name_suffix}.stl: {left_tray_stl}")
+        print(f"Export success case/stl/apiaster-left-frame{args.name_suffix}.stl: {left_frame_stl}")
 
     if 'right' in args.side:
-        print(f"Export success case/stl/apiaster-right-tray{args.name_suffix}.stl: {export_stl(right_tray, f"case/stl/apiaster-right-tray{args.name_suffix}.stl")}")
-        print(f"Export success case/stl/apiaster-right-frame{args.name_suffix}.stl: {export_stl(right_frame, f"case/stl/apiaster-right-frame{args.name_suffix}.stl")}")
+        right_tray_stl = export_stl(right_tray, f"case/stl/apiaster-right-tray{args.name_suffix}.stl")
+        right_frame_stl = export_stl(right_frame, f"case/stl/apiaster-right-frame{args.name_suffix}.stl")
+        print(f"Export success case/stl/apiaster-right-tray{args.name_suffix}.stl: {right_tray_stl}")
+        print(f"Export success case/stl/apiaster-right-frame{args.name_suffix}.stl: {right_frame_stl}")
 
 if not args.no_show:
     from ocp_vscode import *

--- a/case/src/parts/xiao.py
+++ b/case/src/parts/xiao.py
@@ -60,7 +60,8 @@ xiao_box -= xiao_skylights
 xiao_skylight_button = Pos(-6, -2, 2) * Rot(0,0,90) * extrude(SlotCenterToCenter(1, 1.6), 4.7)+\
         Pos(-6, -2.9, 2) * chamfer(extrude(Rectangle(2.6, 6), 2.8).edges().group_by(Axis.Z)[0], 1, 0.5)
 
-print(f"Export success case/stl/apiaster-xiao-button.stl: {export_stl(xiao_skylight_button, f"case/stl/apiaster-xiao-button.stl")}")
+xiao_button_stl = export_stl(xiao_skylight_button, "case/stl/apiaster-xiao-button.stl")
+print(f"Export success case/stl/apiaster-xiao-button.stl: {xiao_button_stl}")
 
 if __name__ == '__main__':
     from ocp_vscode import *


### PR DESCRIPTION
Python 3.10 happens to be what comes with the version of Ubuntu on my WSL2 installation. I noticed that 3.10 does not play nicely with `f""` nested in another `f""`. Rather than changing the quotes to use `f''` in one of those places, I just pulled the inner expression out to a variable assignment. This has the side benefit of reducing line length in that part of the code also.