### PR TITLE
Pin ocpsvg==0.5.0 to fix 'Make Case' workflow

### DIFF
--- a/.github/workflows/make_case.yaml
+++ b/.github/workflows/make_case.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build123d==0.9.1
+          pip install build123d==0.9.1 ocpsvg==0.5.0
 
       - name: Run Python command
         run: |


### PR DESCRIPTION
ocpsvg 0.6.0 introduced an incompatible OCP API change (Wire_s vs Wire). Pinning to 0.5.0 matches the last known working run.